### PR TITLE
Benchmarking for OpenCL code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ configure_file(config.h.in config.h)
 include_directories(include)
 include_directories(include/opencl)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${OpenCL_INCLUDE_DIRS})
 
 add_library(logger STATIC src/logger.c include/logger.h)
 add_library(utils STATIC src/util.c include/util.h)

--- a/include/opencl/opencl_flow_ex3.h
+++ b/include/opencl/opencl_flow_ex3.h
@@ -5,7 +5,8 @@
 #ifndef MULTIPROCOPENCL_OPENCL_FLOW_EX3_H
 #define MULTIPROCOPENCL_OPENCL_FLOW_EX3_H
 #include <opencl_include.h>
+#include <driver.h>
 
-void openclFlowEx3(void);
+void openclFlowEx3(BENCHMARK_MODE benchmark);
 
 #endif //MULTIPROCOPENCL_OPENCL_FLOW_EX3_H

--- a/include/opencl/opencl_flow_ex5.h
+++ b/include/opencl/opencl_flow_ex5.h
@@ -14,7 +14,7 @@ cl_ulong getExecutionTime(cl_event event);
 unsigned long long int
   resize_image(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
 cl_ulong convert_image_to_gray(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
-void apply_zncc(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0, BENCHMARK_MODE benchmark);
+unsigned long long int apply_zncc(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0, BENCHMARK_MODE benchmark);
 void apply_crosscheck(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0, BENCHMARK_MODE benchmark);
 void apply_occlusion_fill(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
 

--- a/include/opencl/opencl_flow_ex5.h
+++ b/include/opencl/opencl_flow_ex5.h
@@ -5,15 +5,17 @@
 #ifndef MULTIPROCOPENCL_OPENCL_FLOW_EX5_H
 #define MULTIPROCOPENCL_OPENCL_FLOW_EX5_H
 #include <opencl_include.h>
+#include <driver.h>
 
-void openclFlowEx5(void);
+void openclFlowEx5(BENCHMARK_MODE benchmark);
 cl_device_id create_device(void);
 cl_program build_program(cl_context ctx, cl_device_id device, const char* filename);
 cl_ulong getExecutionTime(cl_event event);
-void resize_image(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0);
-void convert_image_to_gray(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0);
-void apply_zncc(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0);
-void apply_crosscheck(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0);
-void apply_occlusion_fill(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0);
+unsigned long long int
+  resize_image(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
+cl_ulong convert_image_to_gray(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
+void apply_zncc(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0, BENCHMARK_MODE benchmark);
+void apply_crosscheck(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0, BENCHMARK_MODE benchmark);
+void apply_occlusion_fill(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
 
 #endif //MULTIPROCOPENCL_OPENCL_FLOW_EX5_H

--- a/include/opencl/opencl_flow_ex6.h
+++ b/include/opencl/opencl_flow_ex6.h
@@ -7,8 +7,8 @@
 #include <opencl_include.h>
 
 void printDeviceInformation();
-void openclFlowEx6(void);
-void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0);
+void openclFlowEx6(BENCHMARK_MODE benchmark);
+void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark);
 void printDeviceInformationHelper(cl_device_id device);
 
 #endif //MULTIPROCOPENCL_OPENCL_FLOW_EX6_H

--- a/include/util.h
+++ b/include/util.h
@@ -115,7 +115,7 @@ float standardDeviation(float times[], int numSamples);
  * @param numSamples
  * @return
  */
-float Average(const float *times, const int numSamples);
+float Average(const float *times, int numSamples);
 
 /**
  * Calculate the required sample size for a given standard deviation and mean

--- a/main.c
+++ b/main.c
@@ -50,13 +50,13 @@ int main(int argc, char *argv[])
     }
     else if (strcmp(argv[1], "opencl") == 0)
     {
-        openclFlowEx5();
+        openclFlowEx5(benchmark);
     } else if (strcmp(argv[1], "opencl_opt") == 0)
     {
-        openclFlowEx6();
+        openclFlowEx6(benchmark);
     } else if (strcmp(argv[1], "opencl_old") == 0)
     {
-        openclFlowEx3();
+        openclFlowEx3(benchmark);
     } else if (strcmp(argv[1], "single") == 0)
     {
         fullFlow(benchmark, multithreadedMode);

--- a/project/opencl_flow_ex3/opencl_flow_ex3.c
+++ b/project/opencl_flow_ex3/opencl_flow_ex3.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "config_im_to_g.h"
 
-void apply_gaussian_blur(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0) {
+void apply_gaussian_blur(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark) {
 
     /* Image data */
     cl_mem input_image, output_image;
@@ -86,11 +86,13 @@ void apply_gaussian_blur(cl_context context, cl_kernel kernel, cl_command_queue 
     clReleaseEvent(gaussian_read_event);
     clReleaseEvent(gaussian_event);
 
-    printf("Time taken to do the gaussian blur = %llu ns\n", time_to_gaussian_blur);
-    printf("Time taken to read the output image (gaussian blur) = %llu ns\n", read_time);
+    if (benchmark == DO_NOT_BENCHMARK) {
+        printf("Time taken to do the gaussian blur = %llu ns\n", time_to_gaussian_blur);
+        printf("Time taken to read the output image (gaussian blur) = %llu ns\n", read_time);
+    }
 }
 
-void openclFlowEx3(void) {
+void openclFlowEx3(BENCHMARK_MODE benchmark) {
     printf("OpenCL Flow Example 3 STARTED\n");
     cl_device_id device;
     cl_context context;
@@ -162,13 +164,13 @@ void openclFlowEx3(void) {
     }
 
     /* Resize image size */
-    resize_image(context, kernel_resize_image, queue, im0, output_1_im0);
+    resize_image(context, kernel_resize_image, queue, im0, output_1_im0, benchmark);
 
     /* Convert color image to gray scale image */
-    convert_image_to_gray(context, kernel_color_to_gray, queue, output_1_im0, output_2_im0);
+    convert_image_to_gray(context, kernel_color_to_gray, queue, output_1_im0, output_2_im0, benchmark);
 
     /* Apply gaussian blur with 5 x 5 kernel */
-    apply_gaussian_blur(context, kernel_gaussian_blur, queue, output_2_im0, output_3_im0);
+    apply_gaussian_blur(context, kernel_gaussian_blur, queue, output_2_im0, output_3_im0, benchmark);
 
     saveImage(OUTPUT_1_RESIZE_OPENCL_FILE, output_1_im0);
     saveImage(OUTPUT_1_BW_OPENCL_FILE, output_2_im0);

--- a/project/opencl_flow_ex5/opencl_flow_ex5.c
+++ b/project/opencl_flow_ex5/opencl_flow_ex5.c
@@ -297,7 +297,7 @@ cl_ulong convert_image_to_gray(cl_context context, cl_kernel kernel, cl_command_
     return time_to_grayscale;
 }
 
-void apply_zncc(cl_device_id device,
+unsigned long long int apply_zncc(cl_device_id device,
   cl_context context,
   cl_kernel kernel,
   cl_command_queue queue,
@@ -428,11 +428,14 @@ void apply_zncc(cl_device_id device,
     clReleaseEvent(zncc_read_event);
     clReleaseEvent(zncc_event);
 
-    if (benchmark == DO_NOT_BENCHMARK)
+    if (benchmark == BENCHMARK)
     {
-        printf("Time taken to do the zncc = %llu ns\n", time_to_gaussian_blur);
-        printf("Time taken to read the output image (zncc) = %llu ns\n\n", read_time);
+        return time_to_gaussian_blur;
     }
+
+    logger("Time taken to do the zncc = %llu ns\n", time_to_gaussian_blur);
+    logger("Time taken to read the output image (zncc) = %llu ns\n", read_time);
+    return time_to_gaussian_blur;
 }
 
 void apply_crosscheck(cl_context context,

--- a/project/opencl_flow_ex6/opencl_flow_ex6.c
+++ b/project/opencl_flow_ex6/opencl_flow_ex6.c
@@ -9,6 +9,8 @@
 #include <pngloader.h>
 
 #include "config_im_to_g.h"
+#include "driver.h"
+#include "logger.h"
 #include <opencl_flow_ex5.h>
 #include <opencl_flow_ex6.h>
 #include <stdio.h>
@@ -41,7 +43,11 @@
     }
 
 
-void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0)
+void benchmarkResizeImage(int sampleCount, cl_context pContext, cl_kernel kernel_resize_image, cl_command_queue pQueue, Image *im0, Image *output_1_resized_im0, BENCHMARK_MODE benchmark);
+
+void benchmarkConvertImageToGray(int sampleCount, cl_context pContext, cl_kernel pKernel, cl_command_queue pQueue, Image *im0, Image *output_1_resized_im0, BENCHMARK_MODE benchmark);
+
+void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, Image *output_im0, BENCHMARK_MODE benchmark)
 {
     /* Image data */
     cl_mem input_image, output_image;
@@ -120,7 +126,6 @@ void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel k
     printf("The kernel uses %zu bytes of local memory. It uses %zu bytes of private memory.\n",
       local_usage, private_usage);
 
-
     clFinish(queue);
 
     output_im0->width = width;
@@ -133,8 +138,11 @@ void apply_occlusion_fill_6(cl_device_id device, cl_context context, cl_kernel k
     clReleaseEvent(occlustion_fill_event);
 
 end:
-    printf("Time taken to do the occlustion_fill = %llu ns\n", time_to_occlustion_fill);
-    printf("Time taken to read the output image (occlustion_fill) = %llu ns\n", read_time);
+    if (benchmark == DO_NOT_BENCHMARK)
+    {
+        printf("Time taken to do the occlustion_fill = %llu ns\n", time_to_occlustion_fill);
+        printf("Time taken to read the output image (occlustion_fill) = %llu ns\n", read_time);
+    }
 }
 
 cl_program build_program_6(cl_context ctx, cl_device_id device, const char* filename) {
@@ -184,9 +192,102 @@ cl_program build_program_6(cl_context ctx, cl_device_id device, const char* file
     return program;
 }
 
-void openclFlowEx6(void)
+void apply_crosscheck_6(cl_context context, cl_kernel kernel, cl_command_queue queue, const Image *im0, const Image *im1, Image *output_im0) {
+
+    /* Image data */
+    cl_mem input_image, input_image1, output_image;
+    cl_image_format input_format, input_format1, output_format;
+    int err;
+
+    cl_ulong read_time, time_to_crosscheck;
+
+    cl_event crosscheck_read_event, crosscheck_event;
+
+    const size_t width = im0 -> width;
+    const size_t height = im0 -> height;
+
+    input_format.image_channel_order = CL_RGBA;
+    input_format.image_channel_data_type = CL_UNORM_INT8;
+
+    input_format1.image_channel_order = CL_RGBA;
+    input_format1.image_channel_data_type = CL_UNORM_INT8;
+
+    output_format.image_channel_order = CL_RGBA;
+    output_format.image_channel_data_type = CL_UNORM_INT8;
+
+    /* Create input image object */
+    input_image = clCreateImage2D(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, &input_format, width, height, 0, (void*)im0 -> image, &err);
+    if(err < 0) {
+        printf("crosscheck: Couldn't create the input image 0 object");
+        exit(1);
+    };
+
+    input_image1 = clCreateImage2D(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, &input_format1, width, height, 0, (void*)im1 -> image, &err);
+    if(err < 0) {
+        printf("crosscheck: Couldn't create the input image 1 object");
+        exit(1);
+    };
+
+    /* Create output image object */
+    output_image = clCreateImage2D(context, CL_MEM_READ_WRITE, &output_format, width, height, 0, NULL, &err);
+    if(err < 0) {
+        perror("crosscheck: Couldn't create the input image object");
+        exit(1);
+    };
+
+    // Set kernel arguments
+    err = clSetKernelArg(kernel, 0, sizeof(cl_mem), &input_image);
+    if(err < 0) {
+        perror("crosscheck, Error: clSetKernelArg, inputImage");
+        exit(1);
+    }
+
+    err = clSetKernelArg(kernel, 1, sizeof(cl_mem), &input_image1);
+    if(err < 0) {
+        perror("crosscheck, Error: clSetKernelArg, inputImage");
+        exit(1);
+    }
+
+    err = clSetKernelArg(kernel, 2, sizeof(cl_mem), &output_image);
+    if(err < 0) {
+        perror("crosscheck, Error: clSetKernelArg, outputImage");
+        exit(1);
+    }
+
+    // Execute the OpenCL kernel
+    size_t globalWorkSize[2] = { width , height};
+    err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, globalWorkSize, NULL, 0, NULL, &crosscheck_event);
+    if(err < 0) {
+        perror("crosscheck, Error: clEnqueueNDRangeKernel");
+        exit(1);
+    }
+
+    // Read the output image back to the host
+    err = clEnqueueReadImage(queue, output_image, CL_TRUE, (size_t[3]){0, 0, 0}, (size_t[3]){width, height, 1},
+      0, 0, (void*)output_im0 -> image, 0, NULL, &crosscheck_read_event);
+    if(err < 0) {
+        perror("crosscheck, Error: clEnqueueReadImage");
+        exit(1);
+    }
+
+    clFinish(queue);
+
+    output_im0 -> width = width;
+    output_im0 -> height = height;
+
+    time_to_crosscheck = getExecutionTime(crosscheck_event);
+    read_time = getExecutionTime(crosscheck_read_event);
+
+    clReleaseEvent(crosscheck_read_event);
+    clReleaseEvent(crosscheck_event);
+
+    printf("Time taken to do the crosscheck = %llu ns\n", time_to_crosscheck);
+    printf("Time taken to read the output image (crosscheck) = %llu ns\n", read_time);
+}
+
+void openclFlowEx6(BENCHMARK_MODE benchmark)
 {
-    printf("OpenCL Flow 6 STARTED\n");
+    logger("OpenCL Flow 6 STARTED\n");
     cl_device_id device;
     cl_context context;
     cl_command_queue queue;
@@ -235,7 +336,7 @@ void openclFlowEx6(void)
         exit(1);
     }
 
-    printf("Number of kernels: %u\n", num_kernels);
+    logger("Number of kernels: %u", num_kernels);
 
     /* Create a kernel for each function */
     kernels = (cl_kernel *)malloc(num_kernels * sizeof(cl_kernel));
@@ -248,27 +349,29 @@ void openclFlowEx6(void)
         if (strcmp(kernel_name, KERNEL_RESIZE_IMAGE) == 0)
         {
             kernel_resize_image = kernels[i];
-            printf("Found resize_image kernel at index %u.\n", i);
+            logger("Found `resize_image` kernel at index %u.", i);
         } else if (strcmp(kernel_name, KERNEL_COLOR_TO_GRAY) == 0)
         {
             kernel_color_to_gray = kernels[i];
-            printf("Found color_to_gray kernel at index %u.\n", i);
+            logger("Found `color_to_gray` kernel at index %u.", i);
         } else if (strcmp(kernel_name, KERNEL_ZNCC_LEFT) == 0)
         {
             kernel_zncc_left = kernels[i];
-            printf("Found zncc_left kernel at index %u.\n", i);
+            logger("Found `zncc_left `kernel` at index %u.", i);
         } else if (strcmp(kernel_name, KERNEL_ZNCC_RIGHT) == 0)
         {
             kernel_zncc_right = kernels[i];
-            printf("Found zncc_right kernel at index %u.\n", i);
+            logger("Found `zncc_right kernel` at index %u.", i);
         } else if (strcmp(kernel_name, KERNEL_CROSS_CHECK) == 0)
         {
             kernel_cross_check = kernels[i];
-            printf("Found cross_check kernel at index %u.\n", i);
+            logger("Found `cross_check` kernel at index %u.", i);
         } else if (strcmp(kernel_name, KERNEL_OCCLUSION_FILL) == 0)
         {
             kernel_occlusion_fill = kernels[i];
-            printf("Found occlustion kernel at index %u.\n", i);
+            logger("Found `occlustion` kernel at index %u.", i);
+        } else {
+            logger("Kernel not found");
         }
     }
     // cl_command_queue_properties props[3] = {CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE, 0};
@@ -280,27 +383,42 @@ void openclFlowEx6(void)
         exit(1);
     }
 
-    /* Resize image size */
-    resize_image(context, kernel_resize_image, queue, im0, output_1_resized_im0);
-    /* Convert color image to gray scale image */
-    convert_image_to_gray(context, kernel_color_to_gray, queue, output_1_resized_im0, output_1_bw_im0);
+    logger("Starti running opencl kernels");
+    if (benchmark == BENCHMARK)
+    {
+        logger("Benchmark mode: ON");
+    } else {
+        logger("Benchmark mode: OFF");
+    }
 
-    /* Resize image size */
-    resize_image(context, kernel_resize_image, queue, im1, output_2_resized_im0);
-    /* Convert color image to gray scale image */
-    convert_image_to_gray(context, kernel_color_to_gray, queue, output_2_resized_im0, output_2_bw_im0);
+    int sampleSize = 10;
+    if (benchmark == BENCHMARK)
+    {
+        // Resize Images
+        benchmarkResizeImage(sampleSize, context, kernel_resize_image, queue, im0, output_1_resized_im0, benchmark);
+        benchmarkResizeImage(sampleSize, context, kernel_resize_image, queue, im1, output_2_resized_im0, benchmark);
 
-    /* Apply zncc kernel */
-    apply_zncc(device, context, kernel_zncc_left, queue, output_1_bw_im0, output_2_bw_im0, output_left_disparity_im0);
+        // Convert Images to Gray
+        benchmarkConvertImageToGray(sampleSize, context, kernel_color_to_gray, queue, output_1_resized_im0, output_1_bw_im0, benchmark);
+        benchmarkConvertImageToGray(sampleSize, context, kernel_color_to_gray, queue, output_2_resized_im0, output_2_bw_im0, benchmark);
+    } else
+    {
+        resize_image(context, kernel_resize_image, queue, im0, output_1_resized_im0, benchmark);
+        convert_image_to_gray(context, kernel_color_to_gray, queue, output_1_resized_im0, output_1_bw_im0, benchmark);
 
-    /* Apply zncc kernel */
-    apply_zncc(device, context, kernel_zncc_right, queue, output_2_bw_im0, output_1_bw_im0, output_right_disparity_im0);
+        resize_image(context, kernel_resize_image, queue, im1, output_2_resized_im0, benchmark);
+        convert_image_to_gray(context, kernel_color_to_gray, queue, output_2_resized_im0, output_2_bw_im0, benchmark);
 
-    /* Apply left crosscheck kernel */
-    apply_crosscheck(context, kernel_cross_check, queue, output_left_disparity_im0, output_right_disparity_im0, left_crosscheck_im0);
+        logger("Calculating Left Disparity");
+        apply_zncc(device, context, kernel_zncc_left, queue, output_1_bw_im0, output_2_bw_im0, output_left_disparity_im0, benchmark);
 
-    /* Apply left occlustion fill kernel */
-    apply_occlusion_fill_6(device, context, kernel_occlusion_fill, queue, left_crosscheck_im0, output_left_occlusion_im0);
+        logger("Calculating Right Disparity");
+        apply_zncc(device, context, kernel_zncc_right, queue, output_2_bw_im0, output_1_bw_im0, output_right_disparity_im0, benchmark);
+
+        apply_crosscheck(context, kernel_cross_check, queue, output_left_disparity_im0, output_right_disparity_im0, left_crosscheck_im0, benchmark);
+
+        apply_occlusion_fill_6(device, context, kernel_occlusion_fill, queue, left_crosscheck_im0, output_left_occlusion_im0, benchmark);
+    }
 
     saveImage(OUTPUT_1_RESIZE_OPENCL_FILE, output_1_resized_im0);
     saveImage(OUTPUT_1_BW_OPENCL_FILE, output_1_bw_im0);
@@ -333,7 +451,43 @@ void openclFlowEx6(void)
     clReleaseProgram(program);
     clReleaseContext(context);
 
-    printf("OpenCL Flow 6 ENDED\n");
+    logger("OpenCL Flow 6 ENDED\n");
+}
+
+void benchmarkResizeImage(int sampleCount, cl_context context, cl_kernel kernel_resize_image, cl_command_queue queue, Image *im0, Image *output_1_resized_im0,
+    BENCHMARK_MODE benchmark) {
+    float elapsed_times[sampleCount];
+    for (int i = 0; i < sampleCount; i++) {
+        cl_ulong time = resize_image(context, kernel_resize_image, queue, im0, output_1_resized_im0, benchmark);
+        elapsed_times[i] = (float) time;
+    }
+    float mean = Average(elapsed_times, sampleCount);
+    float sd = standardDeviation(elapsed_times, sampleCount);
+    int req_n = requiredSampleSize(sd, mean);
+    if (req_n > sampleCount) {
+        benchmarkResizeImage(req_n, context, kernel_resize_image, queue, im0, output_1_resized_im0, benchmark);
+    } else {
+        logger("Image Resize kernal ran \t: %d times", sampleCount);
+        logger("Image Resize Time \t\t: %.f  micro seconds", mean/1000);
+    }
+}
+
+void benchmarkConvertImageToGray(int sampleCount, cl_context context, cl_kernel kernel, cl_command_queue queue, Image *im0, Image *output_1_resized_im0,
+  BENCHMARK_MODE benchmark) {
+    float elapsed_times[sampleCount];
+    for (int i = 0; i < sampleCount; i++) {
+        cl_ulong time = convert_image_to_gray(context, kernel, queue, im0, output_1_resized_im0, benchmark);
+        elapsed_times[i] = (float) time;
+    }
+    float mean = Average(elapsed_times, sampleCount);
+    float sd = standardDeviation(elapsed_times, sampleCount);
+    int req_n = requiredSampleSize(sd, mean);
+    if (req_n > sampleCount) {
+        benchmarkConvertImageToGray(req_n, context, kernel, queue, im0, output_1_resized_im0, benchmark);
+    } else {
+        logger("Image Grayscale kernal ran \t: %d times", sampleCount);
+        logger("Image Grayscale Time \t\t: %.f  micro seconds", mean/1000);
+    }
 }
 
 void printDeviceInformation()

--- a/src/util.c
+++ b/src/util.c
@@ -135,19 +135,19 @@ long requiredSampleSize(float sd, float mean)
     return N;
 }
 
-float Average(const float *times, const int numSamples)
+float Average(const float *times, int numSamples)
 {
-    float sum = 0;
+    float sum = 0.0f;
     for (int i = 0; i < numSamples; ++i) { sum += times[i]; }
-    return (double)sum / numSamples;
+    return sum / (float) numSamples;
 }
 
 float standardDeviation(float times[], int numSamples)
 {
     float u = Average(times, numSamples);
     float variance = 0;
-    for (int i = 0; i < numSamples; ++i) { variance += pow(times[i] - u, 2); }
-    variance = variance / numSamples;
+    for (int i = 0; i < numSamples; ++i) { variance += (float) pow(times[i] - u, 2); }
+    variance = variance / (float) numSamples;
     return sqrt(variance);
 }
 


### PR DESCRIPTION
This mode can be run with `./MultiprocOpenCL opencl_opt -benchmark` or  `./MultiprocOpenCL opencl -benchmark`


- [ ] introduce benchmarking for OpenCL
    - [ ] flow 6
        - [x] resize
        - [x] grayscale
        - [x] zncc
        - [ ] crosscheck
        - [ ] occlusion fill
    - [ ] flow 5 
        - [ ] resize
        - [ ] grayscale
        - [ ] zncc
        - [ ] crosscheck
        - [ ] occlusion fill